### PR TITLE
Strip whitespace from comma separated roles

### DIFF
--- a/plugins/role/roles.py
+++ b/plugins/role/roles.py
@@ -87,7 +87,7 @@ class RolePlugin(Plugin):
     def command_role_add(self, event: CommandEvent, role_name):
         roles = role_name.split(",")
         for role in roles:
-            role = self.get_by_alias(role)
+            role = self.get_by_alias(role.strip())
             if role is None:
                 event.msg.reply('Unknown role!')
                 continue


### PR DESCRIPTION
Currently entering the command

```
!role add qut,ifb130,security,c, java
```

fails to add the user to the `java` role as it's interpreted as ` java` (notice the space before). This pull request strips whitespace from each role after splitting to fix.

Note: I haven't actually tested this, as I don't have python installed and I've got no idea how to setup a bot... but I don't see any reason why it wouldn't work :)